### PR TITLE
Fix incorrect variables

### DIFF
--- a/src/main/java/io/cloudtrust/keycloak/eventemitter/EventEmitterProviderFactory.java
+++ b/src/main/java/io/cloudtrust/keycloak/eventemitter/EventEmitterProviderFactory.java
@@ -109,7 +109,7 @@ public class EventEmitterProviderFactory implements EventListenerProviderFactory
             throw e;
         }
 
-        if(bufferCapacity == null){
+        if(keycloakId == null){
             logger.error("KeycloakId configuration is missing");
             throw new IllegalArgumentException("KeycloakId configuration is missing");
         }
@@ -122,7 +122,7 @@ public class EventEmitterProviderFactory implements EventListenerProviderFactory
             throw e;
         }
 
-        if(bufferCapacity == null){
+        if(datacenterId == null){
             logger.error("DatacenterId configuration is missing");
             throw new IllegalArgumentException("DatacenterId configuration is missing");
         }


### PR DESCRIPTION
Looks like bufferCapacity was used instead of other variables. This fixes it.

This got spotted by sonar.